### PR TITLE
fix for MdaTransientPatch.hpp missing definition of exp10f

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,12 @@ ifndef PLATFORM
 endif
 
 ifeq ($(CONFIG),Debug)
-  CPPFLAGS = -g -Wall -Wcpp -Wunused-function -DDEBUG -DUSE_FULL_ASSERT
+  CPPFLAGS = -g -Wall -Wcpp -Wunused-function -DDEBUG -DUSE_FULL_ASSERT -D_GNU_SOURCE=1
   ASFLAGS  = -g
 endif
 
 ifeq ($(CONFIG),Release)
-  CPPFLAGS = -O2
+  CPPFLAGS = -O2 -D_GNU_SOURCE=1
 #  CPPFLAGS += -flto
 #  LDFLAGS += -flto
 endif


### PR DESCRIPTION
Compilation gave me the error:

```
In file included from ./Source/factory.h:43:0,
                 from ./Source/FactoryPatches.cpp:35:
./Libraries/OwlPatches/mdaPorts/MdaTransientPatch.hpp: In member function 'void MdaTransientPatch::setParameters()':
./Libraries/OwlPatches/mdaPorts/MdaTransientPatch.hpp:68:44: error: 'exp10f' was not declared in this scope
  dry = (float)(exp10f((2.0 * fParam3) - 1.0));
```
for version 89f328af27 of the Patches. Fixed the compilation with a additional CPPFLAG for the math.h header included in gcc-arm-none-eabi-5_4-2016q3-20160926-linux.
